### PR TITLE
Hex Multiple Neighbourhood Mass Conservation Cellular Automata

### DIFF
--- a/pages/hex_mn_mcca.html
+++ b/pages/hex_mn_mcca.html
@@ -1,0 +1,28 @@
+<html>
+  <head prefix="og: http://ogp.me/ns#">
+    <title>Hex Multiple Neighbourhood Mass Conservation Cellular Automata</title>
+    <meta property="og:title" content="Hex Multiple Neighbourhood Mass Conservation Cellular Automata" />
+    <meta property="og:description" content="Hex Multiple Neighbourhood Mass Conservation Cellular Automata" />
+    <meta property="og:type" content="article" />
+    <meta property="og:image" content="" />
+    <meta property="og:url" content="https://mitsuyoshi-yamazaki.github.io/ALifeLab/pages/hex_mn_mcca.html" />
+  
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-154586552-1"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() { dataLayer.push(arguments); }
+      gtag('js', new Date());
+
+      gtag('config', 'UA-154586552-1');
+    </script>
+
+    <meta http-equiv="content-type" charset="utf-8">
+  </head>
+
+  <body>
+    <div id="root"></div>
+    
+    <script src="../dist/hex_mn_mcca.js"></script>
+  </body>
+</html>

--- a/src/pages/lab/layout.tsx
+++ b/src/pages/lab/layout.tsx
@@ -35,6 +35,7 @@ const App = () => {
         <LinkCard title="Darwin's Garden" link="garden.html" />
         <LinkCard title="質量保存CA" link="mass_conservation.html" />
         <LinkCard title="多状態質量保存CA" link="mass_conservation_multi_state.html?debug=1&cell_size=12&world_size=80" />
+        <LinkCard title="多近傍質量保存CA" link="hex_mn_mcca.html" />
       </div>
       <Footer homePath="../" />
     </ThemeProvider>

--- a/src/simulations/hex_mn_mcca/cell_state.ts
+++ b/src/simulations/hex_mn_mcca/cell_state.ts
@@ -1,0 +1,3 @@
+export type CellState = {
+  readonly alive: boolean
+}

--- a/src/simulations/hex_mn_mcca/cell_state.ts
+++ b/src/simulations/hex_mn_mcca/cell_state.ts
@@ -1,3 +1,3 @@
-export type CellState = {
-  readonly alive: boolean
-}
+/// 0.0~1.0
+export type CellState = number
+export type AggregatedCellState = number

--- a/src/simulations/hex_mn_mcca/constants.ts
+++ b/src/simulations/hex_mn_mcca/constants.ts
@@ -8,8 +8,9 @@ export const constants = {
     debugValue: parameters.parseFloat("debug_value") ?? 1,
   },
   simulation: {
-    cellSize: parameters.parseInt("cell_size", "si.c") ?? 4,
-    worldSize: parameters.parseInt("world_size", "si.w") ?? 200,
+    cellSize: parameters.parseInt("cell_size", "si.c") ?? 12,
+    worldSize: parameters.parseInt("world_size", "si.w") ?? 720,
+    calculationSpeed: parameters.parseInt("calculation_speed", "si.s") ?? 1,
   },
   parameters: {
   },

--- a/src/simulations/hex_mn_mcca/constants.ts
+++ b/src/simulations/hex_mn_mcca/constants.ts
@@ -1,0 +1,24 @@
+import { URLParameterParser } from "../../classes/url_parameter_parser_v2"
+
+const parameters = new URLParameterParser(document.location.search)
+
+export const constants = {
+  system: {
+    debug: parameters.parseBoolean("debug", "d"),
+    debugValue: parameters.parseFloat("debug_value") ?? 1,
+  },
+  simulation: {
+    cellSize: parameters.parseInt("cell_size", "si.c") ?? 4,
+    worldSize: parameters.parseInt("world_size", "si.w") ?? 200,
+  },
+  parameters: {
+  },
+}
+
+const constantsDescription: string[] = [
+  "constants: ",
+  ...Array.from(Object.values(constants)).flatMap((constantGroup): string[] => {
+    return Array.from(Object.entries(constantGroup)).map(([key, value]) => `${key}: ${value}`)
+  })
+]
+console.log(constantsDescription.join("\n"))

--- a/src/simulations/hex_mn_mcca/constants.ts
+++ b/src/simulations/hex_mn_mcca/constants.ts
@@ -13,6 +13,9 @@ export const constants = {
     calculationSpeed: parameters.parseInt("calculation_speed", "si.s") ?? 1,
   },
   parameters: {
+    initialAliveRatio: parameters.parseFloat("initial_alive_ratio", "p.i") ?? 0.5,
+    kernel: parameters.parseList("float", "kernel", "p.k"),
+    growthFunction: parameters.parseString("growth_function", "p.gf"),
   },
 }
 

--- a/src/simulations/hex_mn_mcca/coordinate.ts
+++ b/src/simulations/hex_mn_mcca/coordinate.ts
@@ -20,3 +20,33 @@ export class HexVector {
     return new HexVector(this.q + other.q, this.r + other.r)
   }
 }
+
+// /**
+//  * Cube Coordinateでアクセスできる、外形が六角形の配列
+//  */
+// export class HexArray<T> {
+//   private content: (T | undefined)[][] = []
+
+//   public constructor(
+//     public readonly size: number,
+//   ) {
+//     this.initialize()
+//   }
+
+//   private initialize(): void {
+//     this.content = (new Array(this.size)).map((_, i): undefined[] => {
+//       if (i <= 0) {
+//         return [undefined]
+//       }
+//       return (new Array(i * 6)).fill(undefined)
+//     })
+//   }
+
+//   public clear(): void {
+//     this.initialize()
+//   }
+
+//   public get(index: HexVector): T | undefined {
+    
+//   }
+// }

--- a/src/simulations/hex_mn_mcca/coordinate.ts
+++ b/src/simulations/hex_mn_mcca/coordinate.ts
@@ -1,0 +1,22 @@
+/**
+ * Cube Coordinate
+ * https://www.redblobgames.com/grids/hexagons/
+ */
+export class HexVector {
+  public s: number
+
+  public constructor(
+    public readonly q: number,
+    public readonly r: number,
+  ) {
+    this.s = 0 - q - r
+  }
+
+  public toString(): string {
+    return `(${this.q},${this.r},${this.s})`
+  }
+
+  public add(other: HexVector): HexVector {
+    return new HexVector(this.q + other.q, this.r + other.r)
+  }
+}

--- a/src/simulations/hex_mn_mcca/growth_function.ts
+++ b/src/simulations/hex_mn_mcca/growth_function.ts
@@ -1,21 +1,29 @@
 import { AggregatedCellState, CellState } from "./cell_state"
 
 export type GrowthFunction = {
-  nextStateOf(currentState: CellState, neighbourSum: AggregatedCellState): CellState
+  nextStateOf(sum: AggregatedCellState): CellState
+}
+
+export const growingGrowthFunction: GrowthFunction = {
+  nextStateOf(sum: AggregatedCellState): CellState {
+    if (sum > 0) {
+      return 1
+    }
+    return -1
+  }
 }
 
 export const exampleGrowthFunction: GrowthFunction = {
-  nextStateOf(currentState: CellState, neighbourSum: AggregatedCellState): CellState {
-    const sum = currentState + neighbourSum
+  nextStateOf(sum: AggregatedCellState): CellState {
     if (sum < 2) {
-      return 0.0
+      return -1
     }
     if (sum < 3) {
-      return currentState
+      return 0
     }
     if (sum < 4.0) {
-      return 1.0
+      return 1
     }
-    return 0.0
+    return -1
   }
 }

--- a/src/simulations/hex_mn_mcca/growth_function.ts
+++ b/src/simulations/hex_mn_mcca/growth_function.ts
@@ -9,21 +9,88 @@ export const growingGrowthFunction: GrowthFunction = {
     if (sum > 0) {
       return 1
     }
-    return -1
+    return 0
   }
 }
 
 export const exampleGrowthFunction: GrowthFunction = {
   nextStateOf(sum: AggregatedCellState): CellState {
     if (sum < 2) {
-      return -1
-    }
-    if (sum < 3) {
       return 0
     }
-    if (sum < 4.0) {
+    if (sum < 4) {
       return 1
     }
-    return -1
+    return 0
+  }
+}
+
+type RangeGrowthFunctionRange = {
+  readonly value: number
+  readonly state: CellState
+}
+
+const ordinalNumber = (value: number): string => {
+  switch (value) {
+  case 1:
+    return "1st"
+  case 2:
+    return "2nd"
+  case 3:
+    return "3rd"
+  default:
+    return `${value}th`
+  }
+}
+
+export class RangeGrowthFunction implements GrowthFunction {
+  public constructor(
+    public readonly ranges: RangeGrowthFunctionRange[],
+  ) {
+  }
+
+  /** @throws */
+  public static parseRanges(rawValue: string): RangeGrowthFunctionRange[] {
+    const rawRanges = rawValue.split(";")
+    return rawRanges.map((rawRange, i) => {
+      const components = rawRange.split(",")
+      if (components.length !== 2) {
+        throw `${ordinalNumber(i)} range ${rawRange} can not split into 2 floating numbers by ','`
+      }
+      const value = parseFloat(components[0])
+      if (isNaN(value) === true) {
+        throw `${ordinalNumber(i)} range ${rawRange} has invalid value ${components[0]}`
+      }
+
+      const state = parseFloat(components[1])
+      if (isNaN(state) === true) {
+        throw `${ordinalNumber(i)} range ${rawRange} has invalid state ${components[1]}`
+      }
+
+      return {
+        value,
+        state,
+      }
+    })
+  }
+
+  public nextStateOf(sum: AggregatedCellState): CellState {
+    for (let i = 0; i < this.ranges.length; i += 1) {
+      const range = this.ranges[i]
+      if (sum < range.value) {
+        return range.state
+      }
+    }
+    return 0
+  }
+}
+
+export class ContinuousGrowthFunction implements GrowthFunction {
+  public constructor(
+  ) {
+  }
+
+  public nextStateOf(sum: AggregatedCellState): CellState {
+    throw "not implemented"
   }
 }

--- a/src/simulations/hex_mn_mcca/growth_function.ts
+++ b/src/simulations/hex_mn_mcca/growth_function.ts
@@ -1,0 +1,21 @@
+import { AggregatedCellState, CellState } from "./cell_state"
+
+export type GrowthFunction = {
+  nextStateOf(currentState: CellState, neighbourSum: AggregatedCellState): CellState
+}
+
+export const exampleGrowthFunction: GrowthFunction = {
+  nextStateOf(currentState: CellState, neighbourSum: AggregatedCellState): CellState {
+    const sum = currentState + neighbourSum
+    if (sum < 2) {
+      return 0.0
+    }
+    if (sum < 3) {
+      return currentState
+    }
+    if (sum < 4.0) {
+      return 1.0
+    }
+    return 0.0
+  }
+}

--- a/src/simulations/hex_mn_mcca/html_arguments.json
+++ b/src/simulations/hex_mn_mcca/html_arguments.json
@@ -1,0 +1,6 @@
+{
+  "page_title": "Hex Multiple Neighbourhood Mass Conservation Cellular Automata",
+  "og_description": "Hex Multiple Neighbourhood Mass Conservation Cellular Automata",
+  "og_image": "",
+  "script_path": "../dist/hex_mn_mcca.js"
+}

--- a/src/simulations/hex_mn_mcca/kernel.ts
+++ b/src/simulations/hex_mn_mcca/kernel.ts
@@ -12,3 +12,10 @@ export const minimumNeighbourKernel: Kernel = {
     1,
   ],
 }
+
+export class GenericKernel implements Kernel {
+  public constructor(
+    public readonly weights: number[],
+  ) {
+  }
+}

--- a/src/simulations/hex_mn_mcca/kernel.ts
+++ b/src/simulations/hex_mn_mcca/kernel.ts
@@ -1,0 +1,14 @@
+/**
+ * 回転対称（異方性のないこと）
+ */
+export type Kernel = {
+  /// 中心に近い方から（index: 0は自身）の重み
+  readonly weights: number[]
+}
+
+export const minimumNeighbourKernel: Kernel = {
+  weights: [
+    1,
+    1,
+  ],
+}

--- a/src/simulations/hex_mn_mcca/layout.tsx
+++ b/src/simulations/hex_mn_mcca/layout.tsx
@@ -1,0 +1,21 @@
+import p5 from "p5"
+import React from "react"
+import ReactDOM from "react-dom"
+import { DetailPage, ScreenshotButtonDefault } from "../../react-components/lab/detail_page"
+import { main, getTimestamp } from "./source"
+
+const App = () => {
+  const screenshotButton: ScreenshotButtonDefault = {
+    kind: "default",
+    getTimestamp,
+    getDescription: () => document.location.search
+  }
+  return (
+    <DetailPage screenshotButtonType={screenshotButton}>
+    </DetailPage>
+  )
+}
+
+ReactDOM.render(<App />, document.getElementById("root"))
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const sketch = new p5(main)

--- a/src/simulations/hex_mn_mcca/model.ts
+++ b/src/simulations/hex_mn_mcca/model.ts
@@ -1,4 +1,6 @@
 import { CellState } from "./cell_state"
+import { GrowthFunction } from "./growth_function"
+import { Kernel } from "./kernel"
 
 export type ModelInitializer = (size: number) => CellState[][]
 
@@ -11,6 +13,8 @@ export class Model {
   
   public constructor(
     public readonly size: number,
+    public readonly kernel: Kernel,
+    public readonly growthFunction: GrowthFunction,
   ) {
   }
 

--- a/src/simulations/hex_mn_mcca/model.ts
+++ b/src/simulations/hex_mn_mcca/model.ts
@@ -1,0 +1,23 @@
+import { CellState } from "./cell_state"
+
+export type ModelInitializer = (size: number) => CellState[][]
+
+export class Model {
+  public get states(): CellState[][] {
+    return this._states
+  }
+
+  private _states: CellState[][] = []
+  
+  public constructor(
+    public readonly size: number,
+  ) {
+  }
+
+  public initialize(initializer: ModelInitializer): void {
+    this._states = initializer(this.size)
+  }
+
+  public step(step: number): void {
+  }
+}

--- a/src/simulations/hex_mn_mcca/model.ts
+++ b/src/simulations/hex_mn_mcca/model.ts
@@ -1,8 +1,45 @@
-import { CellState } from "./cell_state"
+import { AggregatedCellState, CellState } from "./cell_state"
 import { GrowthFunction } from "./growth_function"
 import { Kernel } from "./kernel"
 
 export type ModelInitializer = (size: number) => CellState[][]
+
+const indicesCache = new Map<number, [number, number][]>()
+const indicesOf = (radius: number): [number, number][] => {
+  const cached = indicesCache.get(radius)
+  if (cached != null) {
+    return cached
+  }
+
+  const calculated = ((): [number, number][] => {
+    if (radius <= 0) {
+      return [[0, 0]]
+    }
+
+    return [
+      ...(new Array(radius)).fill(null).map((_, i): [number, number] => [radius, 0 - radius + i]),
+      ...(new Array(radius)).fill(null).map((_, i): [number, number] => [radius - i, i]),
+      ...(new Array(radius)).fill(null).map((_, i): [number, number] => [-i, radius]),
+      ...(new Array(radius)).fill(null).map((_, i): [number, number] => [-radius, radius - i]),
+      ...(new Array(radius)).fill(null).map((_, i): [number, number] => [-radius + i, -i]),
+      ...(new Array(radius)).fill(null).map((_, i): [number, number] => [i, -radius]),
+    ]
+
+    // for (let axis = 0; axis < 3; axis += 1) { // r,q,s,-r,-q,-s
+    //   for (let index = 0; index < i; index += 1) {  // 0->i,0->-i
+    //     // q=2, s=0,-1 => q=2, r=-2,-1
+    //     // s=-2, r=0,1 => q= 0 + radius - r
+    //     // r=2, q=0,-1 
+    //     // q=-2, s=0,1 => q=-radius, r=0-(-radius)-i
+    //     // s= 2, r=0,-1 => q=-radius +i
+    //     // r= -2, q=0,1
+    //   }
+    // }
+  })()
+
+  indicesCache.set(radius, calculated)
+  return calculated
+}
 
 export class Model {
   public get states(): CellState[][] {
@@ -23,5 +60,35 @@ export class Model {
   }
 
   public step(step: number): void {
+    for (let i = 0; i < step; i += 1) {
+      this.calculateNextStep()
+    }
+  }
+
+  private calculateNextStep(): void {
+    const result: CellState[][] = []
+
+    this.states.forEach((row, y) => {
+      const nextRow: CellState[] = []
+      result.push(nextRow)
+
+      row.forEach((state, x) => {
+        const sum = this.sumOf(x, y)
+        const nextState = Math.min(Math.max(state + this.growthFunction.nextStateOf(sum), 0), 1)
+        nextRow.push(nextState)
+      })
+    })
+
+    this._states = result
+  }
+
+  private sumOf(x: number, y: number): AggregatedCellState {
+    return this.kernel.weights.reduce((weightedSum, weight, i) => {
+      return weightedSum + indicesOf(i).reduce((result, localIndex) => {
+        const xIndex = (localIndex[0] + x + this.size) % this.size
+        const yIndex = (localIndex[1] + y + this.size) % this.size
+        return result + this.states[yIndex][xIndex] * weight
+      }, 0)
+    }, 0)
   }
 }

--- a/src/simulations/hex_mn_mcca/model.ts
+++ b/src/simulations/hex_mn_mcca/model.ts
@@ -74,8 +74,7 @@ export class Model {
 
       row.forEach((state, x) => {
         const sum = this.sumOf(x, y)
-        const nextState = Math.min(Math.max(state + this.growthFunction.nextStateOf(sum), 0), 1)
-        nextRow.push(nextState)
+        nextRow.push(this.growthFunction.nextStateOf(sum))
       })
     })
 

--- a/src/simulations/hex_mn_mcca/p5_drawer.ts
+++ b/src/simulations/hex_mn_mcca/p5_drawer.ts
@@ -43,9 +43,10 @@ export class P5Drawer implements Drawer {
           return
         }
 
-        const xPosition = ((y % 2) === 0 ? marginX : 0) + x * distanceX
         const diameter = this.cellSize * state
-        p.circle(xPosition, marginY + y * distanceY, diameter)
+        const xPosition = marginX + y * marginX + x * distanceX
+        const xPositionInCanvas = (xPosition > this.fieldWidth) ? xPosition - this.fieldWidth : xPosition
+        p.circle(xPositionInCanvas, marginY + y * distanceY, diameter)
       })
     })
   }

--- a/src/simulations/hex_mn_mcca/p5_drawer.ts
+++ b/src/simulations/hex_mn_mcca/p5_drawer.ts
@@ -1,0 +1,51 @@
+import p5 from "p5"
+import { Vector } from "../../classes/physics"
+import { Model } from "./model"
+
+export interface Drawer {
+  readonly fieldWidth: number
+  readonly cellSize: number
+  readonly canvasSize: Vector
+
+  drawCanvas(): void
+  drawModel(model: Model): void
+}
+
+export class P5Drawer implements Drawer {
+  public readonly canvasSize: Vector
+
+  public constructor(
+    private readonly p: p5,
+    public readonly fieldWidth: number,
+    public readonly cellSize: number,
+  ) {
+    this.canvasSize = new Vector(fieldWidth, Math.sin(Math.PI / 3) * fieldWidth)
+  }
+
+  public drawCanvas(): void {
+    this.p.clear()
+  }
+
+  drawModel(model: Model): void {
+    const p = this.p
+    const distanceX = this.cellSize
+    const distanceY = Math.sin(Math.PI / 3) * this.cellSize
+    const marginX = distanceX / 2
+    const marginY = distanceY / 2
+
+    p.background(0, 0x00)
+    p.noStroke()
+    p.fill(0x20, 0x80)
+
+    model.states.forEach((row, y) => {
+      row.forEach((state, x) => {
+        // if (state.alive !== true) {
+        //   return
+        // }
+        
+        const xPosition = ((y % 2) === 0 ? marginX : 0) + x * distanceX
+        p.circle(xPosition, marginY + y * distanceY, this.cellSize)
+      })
+    })
+  }
+}

--- a/src/simulations/hex_mn_mcca/p5_drawer.ts
+++ b/src/simulations/hex_mn_mcca/p5_drawer.ts
@@ -33,18 +33,19 @@ export class P5Drawer implements Drawer {
     const marginX = distanceX / 2
     const marginY = distanceY / 2
 
-    p.background(0, 0x00)
+    p.background(0xFF)
     p.noStroke()
-    p.fill(0x20, 0x80)
+    p.fill(0x20, 0xFF)
 
     model.states.forEach((row, y) => {
       row.forEach((state, x) => {
-        // if (state.alive !== true) {
-        //   return
-        // }
-        
+        if (state <= 0) {
+          return
+        }
+
         const xPosition = ((y % 2) === 0 ? marginX : 0) + x * distanceX
-        p.circle(xPosition, marginY + y * distanceY, this.cellSize)
+        const diameter = this.cellSize * state
+        p.circle(xPosition, marginY + y * distanceY, diameter)
       })
     })
   }

--- a/src/simulations/hex_mn_mcca/source.ts
+++ b/src/simulations/hex_mn_mcca/source.ts
@@ -1,7 +1,9 @@
 import p5 from "p5"
+import { random } from "../../classes/utilities"
 import { defaultCanvasParentId } from "../../react-components/common/default_canvas_parent_id"
 import { CellState } from "./cell_state"
-import { HexVector } from "./coordinate"
+import { exampleGrowthFunction } from "./growth_function"
+import { minimumNeighbourKernel } from "./kernel"
 import { Model } from "./model"
 import { P5Drawer } from "./p5_drawer"
 
@@ -10,7 +12,11 @@ const canvasId = "canvas"
 const fieldSize = 720
 const cellSize = 12
 const modelSize = Math.floor(fieldSize / cellSize)
-const model = new Model(modelSize)
+const model = new Model(
+  modelSize,
+  minimumNeighbourKernel,
+  exampleGrowthFunction,
+)
 
 model.initialize(size => {
   const states: CellState[][] = []
@@ -20,16 +26,12 @@ model.initialize(size => {
     states.push(row)
 
     for (let x = 0; x < size; x += 1) {
-      const vector = new HexVector(x, y)
-      if (vector.r === vector.q || vector.q === vector.s || vector.s === vector.r) {
-        // console.log(`${vector}`)
-        row.push({ alive: true })
+      if (random(1) < 0.5) {
+        row.push(1)
       } else {
-        row.push({ alive: false })
+        row.push(0)
       }
     }
-
-    // console.log(`${y}: ${row.map(x => x.alive ? 1 : 0)}`)
   }
   return states
 })

--- a/src/simulations/hex_mn_mcca/source.ts
+++ b/src/simulations/hex_mn_mcca/source.ts
@@ -2,15 +2,16 @@ import p5 from "p5"
 import { random } from "../../classes/utilities"
 import { defaultCanvasParentId } from "../../react-components/common/default_canvas_parent_id"
 import { CellState } from "./cell_state"
-import { exampleGrowthFunction } from "./growth_function"
+import { constants } from "./constants"
+import { exampleGrowthFunction, growingGrowthFunction } from "./growth_function"
 import { minimumNeighbourKernel } from "./kernel"
 import { Model } from "./model"
 import { P5Drawer } from "./p5_drawer"
 
 let t = 0
 const canvasId = "canvas"
-const fieldSize = 720
-const cellSize = 12
+const fieldSize = constants.simulation.worldSize
+const cellSize = constants.simulation.cellSize
 const modelSize = Math.floor(fieldSize / cellSize)
 const model = new Model(
   modelSize,
@@ -26,6 +27,7 @@ model.initialize(size => {
     states.push(row)
 
     for (let x = 0; x < size; x += 1) {
+      // if (x === 50 && y === 50) {
       if (random(1) < 0.5) {
         row.push(1)
       } else {
@@ -48,6 +50,15 @@ export const main = (p: p5): void => {
   }
 
   p.draw = () => {
+    if ((t % 1000) === 0) {
+      console.log(`t: ${t}`)
+    }
+
+    if ((t % constants.simulation.calculationSpeed) !== 0) {
+      t += 1
+      return
+    }
+
     model.step(1)
 
     drawer.drawCanvas()

--- a/src/simulations/hex_mn_mcca/source.ts
+++ b/src/simulations/hex_mn_mcca/source.ts
@@ -1,21 +1,56 @@
 import p5 from "p5"
 import { defaultCanvasParentId } from "../../react-components/common/default_canvas_parent_id"
+import { CellState } from "./cell_state"
+import { HexVector } from "./coordinate"
+import { Model } from "./model"
+import { P5Drawer } from "./p5_drawer"
 
 let t = 0
 const canvasId = "canvas"
-const fieldSize = 600
+const fieldSize = 720
+const cellSize = 12
+const modelSize = Math.floor(fieldSize / cellSize)
+const model = new Model(modelSize)
+
+model.initialize(size => {
+  const states: CellState[][] = []
+
+  for (let y = 0; y < size; y += 1) {
+    const row: CellState[] = []
+    states.push(row)
+
+    for (let x = 0; x < size; x += 1) {
+      const vector = new HexVector(x, y)
+      if (vector.r === vector.q || vector.q === vector.s || vector.s === vector.r) {
+        // console.log(`${vector}`)
+        row.push({ alive: true })
+      } else {
+        row.push({ alive: false })
+      }
+    }
+
+    // console.log(`${y}: ${row.map(x => x.alive ? 1 : 0)}`)
+  }
+  return states
+})
 
 export const main = (p: p5): void => {
+  const drawer = new P5Drawer(p, fieldSize, cellSize)
+
   p.setup = () => {
-    const canvas = p.createCanvas(fieldSize, fieldSize)
+    const canvas = p.createCanvas(drawer.canvasSize.x, drawer.canvasSize.y)
     canvas.id(canvasId)
     canvas.parent(defaultCanvasParentId)
 
-    p.background(0, 0xFF)
+    p.background(0, 0x00)
   }
 
   p.draw = () => {
-    p.background(0, 0xFF)
+    model.step(1)
+
+    drawer.drawCanvas()
+    drawer.drawModel(model)
+
     t += 1
   }
 }

--- a/src/simulations/hex_mn_mcca/source.ts
+++ b/src/simulations/hex_mn_mcca/source.ts
@@ -1,0 +1,25 @@
+import p5 from "p5"
+import { defaultCanvasParentId } from "../../react-components/common/default_canvas_parent_id"
+
+let t = 0
+const canvasId = "canvas"
+const fieldSize = 600
+
+export const main = (p: p5): void => {
+  p.setup = () => {
+    const canvas = p.createCanvas(fieldSize, fieldSize)
+    canvas.id(canvasId)
+    canvas.parent(defaultCanvasParentId)
+
+    p.background(0, 0xFF)
+  }
+
+  p.draw = () => {
+    p.background(0, 0xFF)
+    t += 1
+  }
+}
+
+export const getTimestamp = (): number => {
+  return t
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,7 @@ module.exports = {
     garden: "./src/simulations/garden/layout.tsx",
     mass_conservation: "./src/simulations/mass_conservation/layout.tsx",
     mass_conservation_multi_state: "./src/simulations/mass_conservation_multi_state/layout.tsx",
+    hex_mn_mcca: "./src/simulations/hex_mn_mcca/layout.tsx",
   },
   output: {
     path: path.resolve(__dirname, "dist"),


### PR DESCRIPTION
## Hex grid
2軸で捉えると隣接セルの座標が対称にならないがCube coordinatesだとどの隣接セルも同様の座標変化で求められる
https://www.redblobgames.com/grids/hexagons/

---

# 座標系
Cube coordinate
https://www.redblobgames.com/grids/hexagons/

## Hex Array要件
- cube coordinatesで要素アクセスができる
- 添字と要素がそれぞれ連続すること（普通の二次元配列に突っ込むと空きができる）
- xy座標系に写像できる
- (optional) サイズを可変できる

## 仕様
- cube coordinatesの3軸は2軸で表現可能（任意の1軸は他の2軸から求められる）
- 2軸はxy座標系と全単射可能
  - ただし外形が極端に細長い菱形になる
- 菱形の斜辺を切り取って反対側に埋めることで長方形の外形を得られる
