### PR TITLE
nodeバージョンを指定

### DIFF
--- a/.github/workflows/gh_pages_deploy.yml
+++ b/.github/workflows/gh_pages_deploy.yml
@@ -12,6 +12,9 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       # shellで $cd $GITHUB_WORKSPACE を行いmerge→github.tokenを用いてpushすればdevmasx/merge-branch@v1.3.1を使用せずに書けると思われる
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - name: Deploy
         uses: devmasx/merge-branch@v1.3.1
         with:


### PR DESCRIPTION
GitHub Actionsの

> Error: error:0308010C:digital envelope routines::unsupported
[11](https://github.com/mitsuyoshi-yamazaki/ALifeLab/actions/runs/4210644555/jobs/7308465784#step:7:12)

エラーが治ることを期待する