### PR TITLE
[Modular Life v2.3] 

### DIFF
--- a/src/pages/lab/layout.tsx
+++ b/src/pages/lab/layout.tsx
@@ -37,7 +37,7 @@ const App = () => {
         <LinkCard title="多状態質量保存CA" link="mass_conservation_multi_state.html?debug=1&cell_size=12&world_size=80" />
         <LinkCard title="多近傍質量保存CA" link="hex_mn_mcca.html" />
         <LinkCard title="人工生命の箱庭 v1" link="modular_life.html" />
-        <LinkCard title="人工生命の箱庭 v2" link="modular_life_v2.html" />
+        <LinkCard title="人工生命の箱庭 v2" link="modular_life_v2.html?cell_size=16&world_size=60&frame_skip=1&heat_damage=0.2&energy_heat_conversion=0.1&substance_amount=12&energy_transfer_resistance=5&energy_production=100" />
       </div>
       <Footer homePath="../" />
     </ThemeProvider>

--- a/src/simulations/modular_life_v2/ancestor/ancestor_source_code/energy_collection.ts
+++ b/src/simulations/modular_life_v2/ancestor/ancestor_source_code/energy_collection.ts
@@ -226,10 +226,9 @@ export class EnergyCollection implements SourceCode {
       const modules = api.status.getInternalModules(moduleType)
 
       if (moduleType === "computer") {
-        const newRetainRatio = this.createNewRetainRatio(this.t)
         internalModuleDefinitions.push({
           case: "computer",
-          codeBase: (() => new EnergyCollection(clockwiseDirection(this.direction), newRetainRatio)),
+          codeBase: (() => new EnergyCollection(clockwiseDirection(this.direction), this.createNewRetainRatio(this.t))),  // TODO: thisがゾンビ化していないか確認する
         })
       } else {
         internalModuleDefinitions.push(...modules)
@@ -276,7 +275,7 @@ export class EnergyCollection implements SourceCode {
   }
 
   private createNewRetainRatio(n: number): number {
-    const newRetainRatio = (((n % 3) - 1) / 100)
+    const newRetainRatio = (((Math.floor(n / 10) % 3) - 1) / 100)
     return Math.max(0, Math.min(1, this.retainRatio + newRetainRatio))
   }
 }

--- a/src/simulations/modular_life_v2/ancestor/ancestor_source_code/energy_collection.ts
+++ b/src/simulations/modular_life_v2/ancestor/ancestor_source_code/energy_collection.ts
@@ -3,12 +3,16 @@ import { ComputerApi } from "../../module/api"
 import { AnyModuleDefinition, HullDefinition, ModuleDefinition, ModuleId } from "../../module/module"
 import { InternalModuleType } from "../../module/module_object/module_object"
 import type { SourceCode } from "../../module/source_code"
-import { clockwiseDirection, NeighbourDirection } from "../../physics/direction"
+import { clockwiseDirection, counterClockwiseDirection, NeighbourDirection } from "../../physics/direction"
 import { getShortMaterialName, MaterialAmountMap } from "../../physics/material"
 import { AncestorSpec } from "../spawner"
 
 type LifeStateBorn = {
   readonly case: "born"
+}
+type LifeStateCollectEnergy = {
+  readonly case: "collectEnergy"
+  energyAmount: number
 }
 type LifeStateCollectResource = {
   readonly case: "collectResource"
@@ -25,7 +29,12 @@ type LifeStateConstructChild = {
 type LifeStatePregnant = {
   readonly case: "pregnant"
 }
-type LifeState = LifeStateBorn | LifeStateCollectResource | LifeStateReproduction | LifeStateConstructChild | LifeStatePregnant
+type LifeState = LifeStateBorn
+  | LifeStateCollectResource
+  | LifeStateCollectEnergy
+  | LifeStateReproduction
+  | LifeStateConstructChild
+  | LifeStatePregnant
 
 type StaticParameters = {
   readonly moveEnergyConsumption: number
@@ -35,16 +44,16 @@ type StaticParameters = {
   readonly hullId: ModuleId<"hull">
 }
 
-export class MinimumSelfReproductionCode implements SourceCode {
+export class EnergyCollection implements SourceCode {
   private t = 0
   private state: LifeState = {
     case: "born",
   }
 
   private staticParameters = null as StaticParameters | null  // 計算量削減 & 変化しないので一度だけ取得した値を保管する
-  
+
   public constructor(
-    private readonly direction: NeighbourDirection,
+    private direction: NeighbourDirection,
   ) {
   }
 
@@ -57,36 +66,66 @@ export class MinimumSelfReproductionCode implements SourceCode {
       api.action.uptake(channel.id)
     })
 
+    if (this.t % 500 === 499) {
+      this.direction = counterClockwiseDirection(this.direction)
+    }
+
     switch (this.state.case) {
     case "born":
       if (this.t % 10 === 0) {
         if (api.status.getEnergyAmount() >= api.status.getMoveEnergyConsumption()) {
           api.action.move(this.direction)
           this.state = {
-            case: "collectResource",
-            substanceAmount: api.status.getStoredAmount("substance"),
-          }
-        }
-      }
-      break
-
-    case "collectResource":
-      if (this.t % 10 === 0) {
-        const substanceAmount = api.status.getStoredAmount("substance")
-        if (substanceAmount <= this.state.substanceAmount && api.status.getEnergyAmount() >= api.status.getMoveEnergyConsumption()) {
-          api.action.move(this.direction)
-        }
-
-        this.state.substanceAmount = substanceAmount
-
-        if (this.hasEnoughResourceToReproduce(api, this.staticParameters.assembleIngredients) === true) {
-          this.state = {
-            case: "reproduction",
+            case: "collectEnergy",
+            energyAmount: api.status.getEnergyAmount(),
           }
         }
       }
       break
       
+    case "collectEnergy": {
+      if (this.t % 10 === 0) {
+        const energyAmount = api.status.getEnergyAmount()
+        if (energyAmount > 400) {
+          this.state = {
+            case: "collectResource",
+            substanceAmount: api.status.getStoredAmount("substance"),
+          }
+        } else {
+          if (energyAmount <= this.state.energyAmount) {
+            api.action.move(this.direction)
+          }
+
+          this.state.energyAmount = energyAmount
+        }
+      }
+      break
+    }
+
+    case "collectResource":
+      if (this.t % 10 === 0) {
+        if (api.status.getEnergyAmount() < 100) {
+          this.state = {
+            case: "collectEnergy",
+            energyAmount: api.status.getEnergyAmount(),
+          }
+        } else {
+          const substanceAmount = api.status.getStoredAmount("substance")
+          if (substanceAmount <= this.state.substanceAmount && api.status.getEnergyAmount() >= api.status.getMoveEnergyConsumption()) {
+            api.action.move(this.direction)
+          }
+
+          this.state.substanceAmount = substanceAmount
+
+          if (this.hasEnoughResourceToReproduce(api, this.staticParameters.assembleIngredients) === true) {
+            this.state = {
+              case: "reproduction",
+            }
+          }
+        }
+      }
+      break
+
     case "reproduction":
       if (this.t % 10 === 0) {
         const children = api.status.getNestedHull()
@@ -141,13 +180,13 @@ export class MinimumSelfReproductionCode implements SourceCode {
       break
 
     default: {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const _: never = this.state
       throw `unexpected state ${(this.state as LifeState).case}`
     }
     }
 
-    api.action.say("M")
+    api.action.say("E")
 
     this.t += 1
   }
@@ -181,7 +220,7 @@ export class MinimumSelfReproductionCode implements SourceCode {
       if (moduleType === "computer") {
         internalModuleDefinitions.push({
           case: "computer",
-          codeBase: (() => new MinimumSelfReproductionCode(clockwiseDirection(this.direction))),
+          codeBase: (() => new EnergyCollection(clockwiseDirection(this.direction))),
         })
       } else {
         internalModuleDefinitions.push(...modules)

--- a/src/simulations/modular_life_v2/ancestor/ancestor_source_code/example.ts
+++ b/src/simulations/modular_life_v2/ancestor/ancestor_source_code/example.ts
@@ -1,0 +1,43 @@
+import { ComputerApi } from "../../module/api"
+import { AnyModuleDefinition, ModuleId } from "../../module/module"
+import { SourceCode } from "../../module/source_code"
+
+export class ExampleCode implements SourceCode {
+  public constructor(
+  ) {
+  }
+
+  public run(api: ComputerApi): void {
+    const codeBase: () => SourceCode = () => (new ExampleCode())
+
+    api.status.getInternalModules("channel").forEach(channel => {
+      api.action.uptake(channel.id)
+    })
+
+    if (api.status.getEnergyAmount() >= 1000) {
+      const assembler = api.status.getInternalModules("assembler")[0]
+
+      // Mutating moduleDefinitions alters child's ability
+      // Mutating codeBase alteres child's behavior
+      const moduleDefinitions: AnyModuleDefinition[] = [
+        { case: "hull", size: 5 },
+        { case: "computer", codeBase },
+        { case: "assembler" },
+        { case: "channel", materialType: "energy" },
+        { case: "mover" },
+      ]
+
+      moduleDefinitions.forEach(moduleDefinition => {
+        api.action.assemble(assembler.id, this.assembleTarget(), moduleDefinition)
+      })
+    }
+  }
+
+  private assembleTarget(): ModuleId<"hull"> {
+    throw "dummy"
+  }
+
+  private nextModuleDefinitionToAssemble(): AnyModuleDefinition {
+    throw "dummy"
+  }
+}

--- a/src/simulations/modular_life_v2/ancestor/source_code.ts
+++ b/src/simulations/modular_life_v2/ancestor/source_code.ts
@@ -22,7 +22,7 @@ export const AncestorCode = {
       run(api: ComputerApi): void {
         api.action.say(`t: ${this.t}`)
 
-        api.status.getModules("channel").forEach(channel => {
+        api.status.getInternalModules("channel").forEach(channel => {
           api.action.uptake(channel.id)
         })
 

--- a/src/simulations/modular_life_v2/ancestor/source_code.ts
+++ b/src/simulations/modular_life_v2/ancestor/source_code.ts
@@ -1,8 +1,6 @@
 import { ComputerApi } from "../module/api"
 import type { SourceCode } from "../module/source_code"
 import { NeighbourDirection } from "../physics/direction"
-import { EnergyCollection } from "./ancestor_source_code/energy_collection"
-import { MinimumSelfReproductionCode } from "./ancestor_source_code/minimum_self_reproduction"
 
 export const AncestorCode = {
   /// ゲーム世界上で何も行わない
@@ -34,14 +32,5 @@ export const AncestorCode = {
         this.t += 1
       },
     } as { t: number, run(api: ComputerApi): void }
-  },
-
-  /// 自己複製を行う
-  minimumSelfReproduction(direction: NeighbourDirection): SourceCode {
-    return new MinimumSelfReproductionCode(direction)
-  },
-
-  energyCollection(direction: NeighbourDirection): SourceCode {
-    return new EnergyCollection(direction)
   },
 }

--- a/src/simulations/modular_life_v2/ancestor/source_code.ts
+++ b/src/simulations/modular_life_v2/ancestor/source_code.ts
@@ -1,6 +1,7 @@
 import { ComputerApi } from "../module/api"
 import type { SourceCode } from "../module/source_code"
 import { NeighbourDirection } from "../physics/direction"
+import { EnergyCollection } from "./ancestor_source_code/energy_collection"
 import { MinimumSelfReproductionCode } from "./ancestor_source_code/minimum_self_reproduction"
 
 export const AncestorCode = {
@@ -38,5 +39,9 @@ export const AncestorCode = {
   /// 自己複製を行う
   minimumSelfReproduction(direction: NeighbourDirection): SourceCode {
     return new MinimumSelfReproductionCode(direction)
+  },
+
+  energyCollection(direction: NeighbourDirection): SourceCode {
+    return new EnergyCollection(direction)
   },
 }

--- a/src/simulations/modular_life_v2/api_request.ts
+++ b/src/simulations/modular_life_v2/api_request.ts
@@ -27,6 +27,7 @@ export type ComputeRequestSynthesize = {
 export type ComputeRequestAssemble = {
   readonly case: "assemble"
   readonly module: Assembler
+  readonly targetHull: Hull
   readonly moduleDefinition: ModuleDefinition<ModuleType>
 }
 

--- a/src/simulations/modular_life_v2/constants.ts
+++ b/src/simulations/modular_life_v2/constants.ts
@@ -24,6 +24,7 @@ export const constants = {
     cellSize: parameters.parseInt("cell_size", { alternativeKey: "si.c", min: 1 }) ?? 16,
     worldSize: parameters.parseInt("world_size", { alternativeKey: "si.w", min: 4 }) ?? 40,
     frameSkip: parameters.parseInt("frame_skip", { alternativeKey: "si.f", min: 1 }) ?? 2,
+    substanceAmount: parameters.parseInt("substance_amount", { min: 1 }) ?? 500
   },
   physicalConstant,
 }

--- a/src/simulations/modular_life_v2/constants.ts
+++ b/src/simulations/modular_life_v2/constants.ts
@@ -11,6 +11,7 @@ const physicalConstant: PhysicalConstant = {
   heatLossRate: parameters.parseFloat("heat_loss", { alternativeKey: "ph.h", min: 0 }) ?? 0.25,
   energyHeatConversionRate: parameters.parseFloat("energy_heat_conversion", { alternativeKey: "ph.e", min: 0 }) ?? 0.5,
   heatDamage: parameters.parseFloat("heat_damage", { alternativeKey: "ph.d", min: 0 }) ?? 0.1,
+  retainEnergyConsumptionRate: parameters.parseFloat("retain_energy_consumption_rate", { min: 1 }) ?? 0.01,
   energyTransferResistance: parameters.parseInt("energy_transfer_resistance", { min: 1 }) ?? 50,
 
   materialProductionRecipe: materialProductionRecipes,

--- a/src/simulations/modular_life_v2/constants.ts
+++ b/src/simulations/modular_life_v2/constants.ts
@@ -11,6 +11,7 @@ const physicalConstant: PhysicalConstant = {
   heatLossRate: parameters.parseFloat("heat_loss", { alternativeKey: "ph.h", min: 0 }) ?? 0.25,
   energyHeatConversionRate: parameters.parseFloat("energy_heat_conversion", { alternativeKey: "ph.e", min: 0 }) ?? 0.5,
   heatDamage: parameters.parseFloat("heat_damage", { alternativeKey: "ph.d", min: 0 }) ?? 0.1,
+  energyTransferResistance: parameters.parseInt("energy_transfer_resistance", { min: 1 }) ?? 50,
 
   materialProductionRecipe: materialProductionRecipes,
 }
@@ -24,7 +25,9 @@ export const constants = {
     cellSize: parameters.parseInt("cell_size", { alternativeKey: "si.c", min: 1 }) ?? 16,
     worldSize: parameters.parseInt("world_size", { alternativeKey: "si.w", min: 4 }) ?? 40,
     frameSkip: parameters.parseInt("frame_skip", { alternativeKey: "si.f", min: 1 }) ?? 2,
-    substanceAmount: parameters.parseInt("substance_amount", { min: 1 }) ?? 500
+
+    substanceAmount: parameters.parseInt("substance_amount", { min: 1 }) ?? 500,
+    energyProduction: parameters.parseInt("energy_production", { min: 1 }) ?? 500,
   },
   physicalConstant,
 }

--- a/src/simulations/modular_life_v2/engine.ts
+++ b/src/simulations/modular_life_v2/engine.ts
@@ -3,7 +3,6 @@ import { strictEntries } from "../../classes/utilities"
 import { ComputeRequestAssemble, ComputeRequestExcretion, ComputeRequestSynthesize, ComputeRequestUptake, GenericComputeRequest, Life, MaterialTransferRequestType } from "./api_request"
 import { Logger } from "./logger"
 import { AnyModuleDefinition } from "./module/module"
-import { Hull } from "./module/module_object/hull"
 import { AnyModule, createModule, InternalModuleType } from "./module/module_object/module_object"
 import { ModuleSpec } from "./module/module_spec"
 import { MaterialAmountMap, materialProductionRecipes } from "./physics/material"
@@ -50,15 +49,7 @@ export class Engine {
     })
   }
 
-  private runAssemble(life: Life, requests: ComputeRequestAssemble[]): void {
-    if (life.hull[0] != null) {
-      this.assemble(life, life.hull[0], requests)
-    } else {
-      this.assemble(life, life, requests)
-    }
-  }
-
-  private assemble(materialStore: Scope, hull: Hull, requests: ComputeRequestAssemble[]): void {
+  private runAssemble(materialStore: Scope, requests: ComputeRequestAssemble[]): void {
     requests.forEach(request => {
       const ingredients = this.getAssembleIngredientsFor(request.moduleDefinition)
       if (this.hasEnoughIngredients(materialStore, ingredients) !== true) {
@@ -68,14 +59,14 @@ export class Engine {
 
       switch (request.moduleDefinition.case) {
       case "hull":
-        hull.hull.push(createModule<"hull">(request.moduleDefinition))
+        request.targetHull.hull.push(createModule<"hull">(request.moduleDefinition))
         break
       case "assembler":
       case "computer":
       case "channel":
       case "mover":
       case "materialSynthesizer":
-        hull.addInternalModule(createModule<InternalModuleType>(request.moduleDefinition))
+        request.targetHull.addInternalModule(createModule<InternalModuleType>(request.moduleDefinition))
         break
       default: {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/simulations/modular_life_v2/engine.ts
+++ b/src/simulations/modular_life_v2/engine.ts
@@ -104,13 +104,16 @@ export class Engine {
   }
 
   private runUptake(scope: Scope, life: Life, requests: ComputeRequestUptake[]): void {
+    let remainingCapacity = life.capacity - Array.from(Object.values(life.amount)).reduce((result, current) => result + current, 0)
+
     requests.forEach(request => {
       const materialType = request.module.materialType
-      const amount = Math.min(scope.scopeUpdate.amount[materialType], ModuleSpec.modules.channel.maxTransferAmount)
+      const amount = Math.min(scope.scopeUpdate.amount[materialType], ModuleSpec.modules.channel.maxTransferAmount, remainingCapacity)
       if (amount <= 0) {
         return
       }
 
+      remainingCapacity -= amount
       scope.scopeUpdate.amount[materialType] -= amount
       life.scopeUpdate.amount[materialType] += amount
     })

--- a/src/simulations/modular_life_v2/engine.ts
+++ b/src/simulations/modular_life_v2/engine.ts
@@ -40,7 +40,7 @@ export class Engine {
 
       const synthesizeRequests = operation.requests.synthesize
       if (synthesizeRequests.length > 0) {
-        this.runSynthesize(operation.life, synthesizeRequests)
+        this.runSynthesize(operation.life, scope, synthesizeRequests)
       }
 
       const uptakeRequests = operation.requests.uptake
@@ -87,7 +87,7 @@ export class Engine {
     return ModuleSpec.moduleIngredients[moduleDefinition.case]
   }
 
-  private runSynthesize(life: Life, requests: ComputeRequestSynthesize[]): void {
+  private runSynthesize(life: Life, inScope: Scope, requests: ComputeRequestSynthesize[]): void {
     requests.forEach(request => {
       const recipe = materialProductionRecipes[request.module.recipeName]
       if (this.hasEnoughIngredients(life, recipe.ingredients) !== true) {
@@ -96,7 +96,7 @@ export class Engine {
       this.consumeMaterials(life, recipe.ingredients)
       this.addMaterials(life, recipe.productions)
 
-      life.scopeUpdate.heat += recipe.heatProduction
+      inScope.scopeUpdate.heat += recipe.heatProduction
     })
   }
 

--- a/src/simulations/modular_life_v2/engine.ts
+++ b/src/simulations/modular_life_v2/engine.ts
@@ -228,8 +228,20 @@ export class Engine {
     return Result.Succeeded(energyConsumption)
   }
 
+  private getHeatDamate(heat: number): number {
+    return Math.ceil((heat + 1) * this.physicalConstant.heatDamage)
+  }
+
+  public getRetainEnergyConsumption(life: Life, heat: number): number {
+    return Math.ceil(Math.pow(life.size, 2) * this.getHeatDamate(heat) * this.physicalConstant.retainEnergyConsumptionRate)
+  }
+
   public calculateHeatDamage(life: Life, inScope: Scope): void {
-    life.hits -= Math.ceil(inScope.scopeUpdate.heat * this.physicalConstant.heatDamage)
+    const retainPower = life.retainEnergyBank / this.getRetainEnergyConsumption(life, inScope.heat)
+    const heatDamage = Math.ceil(this.getHeatDamate(inScope.heat) * (1 - retainPower))
+
+    life.hits -= heatDamage
+    life.retainEnergyBank = 0
 
     if (life.hits > 0) {
       return

--- a/src/simulations/modular_life_v2/layout.tsx
+++ b/src/simulations/modular_life_v2/layout.tsx
@@ -1,5 +1,5 @@
 import p5 from "p5"
-import React, { useEffect, useState } from "react"
+import React, { CSSProperties, useEffect, useState } from "react"
 import ReactDOM from "react-dom"
 import { strictEntries } from "../../classes/utilities"
 import { DetailPage, ScreenshotButtonDefault } from "../../react-components/lab/detail_page"
@@ -40,8 +40,29 @@ const App = () => {
     setCurrentState(event, newValue)
   })
 
+  const descriptionStyle: CSSProperties = {
+    margin: DetailPage.defaultContentMargin
+  }
+  const borderStyle: CSSProperties = {
+    backgroundColor: "rgba(212, 214, 245, 1.0)",
+    width: "100%",
+    height: "1px",
+    border: "none",
+  }
+
   return (
     <DetailPage screenshotButtonType={screenshotButton}>
+      <div style={descriptionStyle}>
+        <h2>{document.title}</h2>
+        <hr style={borderStyle}></hr>
+        キー操作：
+        <ul style={{ paddingLeft: "2rem" }}>
+          <li>0: 停止/再開</li>
+          <li>1: エネルギー表示/非表示</li>
+          <li>2: 熱表示/非表示</li>
+          <li>3: 物質表示/非表示</li>
+        </ul>
+      </div>
     </DetailPage>
   )
 }

--- a/src/simulations/modular_life_v2/module/api.ts
+++ b/src/simulations/modular_life_v2/module/api.ts
@@ -29,11 +29,14 @@ export type ComputerApi = {
 
     getWeight(): number
     getMoveEnergyConsumption(): number
+    getRetainEnergyConsumption(): number
   }
 
   readonly action: {
     say(message: string | null): void
 
+    /// Hull.hitsの減少を抑制する
+    retain(energyAmount: number): void
     move(direction: NeighbourDirection): void
     uptake(moduleId: ModuleId<"channel">): void
     excretion(moduleId: ModuleId<"channel">): void

--- a/src/simulations/modular_life_v2/module/api.ts
+++ b/src/simulations/modular_life_v2/module/api.ts
@@ -8,7 +8,10 @@ export type ComputerApi = {
   }
 
   readonly environment: {
-    getEnvironmentalHeat(): number
+    /// 空（単一Scope内にいる）なら移動はできない：親の体内にいるかどうかを判別するのに使用できる
+    movableDirections(): NeighbourDirection[]
+
+    getHeat(): number
 
     /// そのScopeに存在するModuleの総重量
     getWeight(): number

--- a/src/simulations/modular_life_v2/module/api.ts
+++ b/src/simulations/modular_life_v2/module/api.ts
@@ -1,6 +1,8 @@
 import type { NeighbourDirection } from "../physics/direction"
 import type { MaterialAmountMap, MaterialType } from "../physics/material"
-import type { AnyModuleDefinition, ModuleId, ModuleInterface, ModuleType } from "./module"
+import type { AnyModuleDefinition, ModuleId, ModuleInterface } from "./module"
+import type { Hull } from "./module_object/hull"
+import type { InternalModuleType } from "./module_object/module_object"
 
 export type ComputerApi = {
   readonly physics: {
@@ -22,7 +24,9 @@ export type ComputerApi = {
     getEnergyAmount(): number
     getHeat(): number
 
-    getModules<M extends ModuleType>(moduleType: M): ModuleInterface<M>[]
+    getInternalModules<M extends InternalModuleType>(moduleType: M): ModuleInterface<M>[]
+    getHull(): Hull
+    getNestedHull(): Hull[]
 
     getWeight(): number
     getMoveEnergyConsumption(): number
@@ -35,6 +39,6 @@ export type ComputerApi = {
     uptake(moduleId: ModuleId<"channel">): void
     excretion(moduleId: ModuleId<"channel">): void
     synthesize(moduleId: ModuleId<"materialSynthesizer">): void
-    assemble(moduleId: ModuleId<"assembler">, moduleDefinition: AnyModuleDefinition): void
+    assemble(moduleId: ModuleId<"assembler">, hullId: ModuleId<"hull">, moduleDefinition: AnyModuleDefinition): void
   }
 }

--- a/src/simulations/modular_life_v2/module/api.ts
+++ b/src/simulations/modular_life_v2/module/api.ts
@@ -1,7 +1,6 @@
 import type { NeighbourDirection } from "../physics/direction"
 import type { MaterialAmountMap, MaterialType } from "../physics/material"
-import type { AnyModuleDefinition, ModuleId, ModuleInterface } from "./module"
-import type { Hull } from "./module_object/hull"
+import type { AnyModuleDefinition, HullInterface, ModuleId, ModuleInterface } from "./module"
 import type { InternalModuleType } from "./module_object/module_object"
 
 export type ComputerApi = {
@@ -25,8 +24,8 @@ export type ComputerApi = {
     getHeat(): number
 
     getInternalModules<M extends InternalModuleType>(moduleType: M): ModuleInterface<M>[]
-    getHull(): Hull
-    getNestedHull(): Hull[]
+    getHull(): HullInterface
+    getNestedHull(): HullInterface[]
 
     getWeight(): number
     getMoveEnergyConsumption(): number

--- a/src/simulations/modular_life_v2/module/module.ts
+++ b/src/simulations/modular_life_v2/module/module.ts
@@ -28,6 +28,7 @@ export type HullDefinition = BaseModuleDefinition<"hull"> & {
 export type HullInterface = BaseModuleInterface<"hull"> & Scope & HullDefinition & {
   readonly hits: number
   readonly hitsMax: number
+  readonly capacity: number
 }
 
 export type ComputerDefinition = BaseModuleDefinition<"computer"> & {

--- a/src/simulations/modular_life_v2/module/module_object/hull.ts
+++ b/src/simulations/modular_life_v2/module/module_object/hull.ts
@@ -1,7 +1,11 @@
-import { createMaterialStore, createScopeId, createScopeUpdate, MaterialStore, ScopeUpdate } from "../../physics/scope"
+import { createMaterialStore, createScopeId, createScopeUpdate, MaterialStore, Scope, ScopeUpdate } from "../../physics/scope"
 import { HullInterface } from "../module"
 import { AbstractModule } from "./abstract_module"
 import type { AnyModule, InternalModuleType, Module } from "./module_object"
+
+export const isHull = (scope: Scope): scope is Hull => {
+  return (scope as Partial<Hull>).case === "hull"
+}
 
 export class Hull extends AbstractModule<"hull"> implements HullInterface {
   public readonly case = "hull"

--- a/src/simulations/modular_life_v2/module/module_object/hull.ts
+++ b/src/simulations/modular_life_v2/module/module_object/hull.ts
@@ -25,6 +25,7 @@ export class Hull extends AbstractModule<"hull"> implements HullInterface {
   public readonly capacity: number
   public heat = 0
   public saying: string | null = null
+  public retainEnergyBank = 0
 
   public readonly hull: Hull[] = []
 

--- a/src/simulations/modular_life_v2/module/source_code.ts
+++ b/src/simulations/modular_life_v2/module/source_code.ts
@@ -1,5 +1,7 @@
 import type { ComputerApi } from "./api"
 
 export type SourceCode = {
+  // readonly hash: string  // TODO: 進化の検出用
+
   run(api: ComputerApi): void
 }

--- a/src/simulations/modular_life_v2/physics/physical_constant.ts
+++ b/src/simulations/modular_life_v2/physics/physical_constant.ts
@@ -4,6 +4,7 @@ export type PhysicalConstant = {
   readonly heatLossRate: number
   readonly energyHeatConversionRate: number
   readonly heatDamage: number
+  readonly retainEnergyConsumptionRate: number
   readonly energyTransferResistance: number
 
   readonly materialProductionRecipe: { [RecipeName in MaterialRecipeName]: ProductionRecipe }

--- a/src/simulations/modular_life_v2/physics/physical_constant.ts
+++ b/src/simulations/modular_life_v2/physics/physical_constant.ts
@@ -4,6 +4,7 @@ export type PhysicalConstant = {
   readonly heatLossRate: number
   readonly energyHeatConversionRate: number
   readonly heatDamage: number
+  readonly energyTransferResistance: number
 
   readonly materialProductionRecipe: { [RecipeName in MaterialRecipeName]: ProductionRecipe }
 }

--- a/src/simulations/modular_life_v2/source.ts
+++ b/src/simulations/modular_life_v2/source.ts
@@ -138,21 +138,31 @@ export const main = (): ReactConnector => {
 }
 
 function initializeEnergySources(world: World): void {
-  const centerPosition = world.size.div(2).floor()
-  const energyProductionRadius = Math.floor(world.size.x * 0.3)
-  const maxEnergyProduction = 10
-
-  const minimumEnergyProductionPosition = Math.floor(world.size.x / 2 - energyProductionRadius)
-  const maximumEnergyProductionPosition = world.size.x - minimumEnergyProductionPosition
-
-  for (let y = minimumEnergyProductionPosition; y < maximumEnergyProductionPosition; y += 1) {
-    for (let x = minimumEnergyProductionPosition; x < maximumEnergyProductionPosition; x += 1) {
-      const distanceToCenter = (new Vector(x, y)).dist(centerPosition)
-      const closenessToCenter = 1 - (distanceToCenter / energyProductionRadius)
-      const energyProduction = Math.floor(closenessToCenter * maxEnergyProduction)
-      world.setEnergyProductionAt(x, y, energyProduction)
-    }
+  const setEnergyProduction = (position: Vector): void => {
+    world.setEnergyProductionAt(position.x, position.y, constants.simulation.energyProduction)
   }
+
+  const centerPosition = world.size.div(2).floor()
+  setEnergyProduction(centerPosition.div(2).floor())
+  setEnergyProduction(centerPosition)
+  setEnergyProduction(centerPosition.div(2).mult(3).floor())
+  
+
+  // const centerPosition = world.size.div(2).floor()
+  // const energyProductionRadius = Math.floor(world.size.x * 0.3)
+  // const maxEnergyProduction = 10
+
+  // const minimumEnergyProductionPosition = Math.floor(world.size.x / 2 - energyProductionRadius)
+  // const maximumEnergyProductionPosition = world.size.x - minimumEnergyProductionPosition
+
+  // for (let y = minimumEnergyProductionPosition; y < maximumEnergyProductionPosition; y += 1) {
+  //   for (let x = minimumEnergyProductionPosition; x < maximumEnergyProductionPosition; x += 1) {
+  //     const distanceToCenter = (new Vector(x, y)).dist(centerPosition)
+  //     const closenessToCenter = 1 - (distanceToCenter / energyProductionRadius)
+  //     const energyProduction = Math.floor(closenessToCenter * maxEnergyProduction)
+  //     world.setEnergyProductionAt(x, y, energyProduction)
+  //   }
+  // }
 }
 
 function initializeMaterials(world: World): void {

--- a/src/simulations/modular_life_v2/source.ts
+++ b/src/simulations/modular_life_v2/source.ts
@@ -166,7 +166,9 @@ function initializeMaterials(world: World): void {
 }
 
 function initializeAncestors(world: World): void {
-  world.addAncestor(Ancestor.minimumSelfReproduction(() => AncestorCode.minimumSelfReproduction(NeighbourDirections.bottom)), world.size.div(3).floor())
-  world.addAncestor(Ancestor.minimumSelfReproduction(() => AncestorCode.minimumSelfReproduction(NeighbourDirections.right)), world.size.div(2).floor())
-  world.addAncestor(Ancestor.minimumSelfReproduction(() => AncestorCode.minimumSelfReproduction(NeighbourDirections.top)), world.size.div(3).mult(2).floor())
+  world.addAncestor(Ancestor.minimumSelfReproduction(() => AncestorCode.energyCollection(NeighbourDirections.bottom)), world.size.div(3).floor())
+  world.addAncestor(Ancestor.minimumSelfReproduction(() => AncestorCode.energyCollection(NeighbourDirections.right)), world.size.div(2).floor())
+  world.addAncestor(Ancestor.minimumSelfReproduction(() => AncestorCode.energyCollection(NeighbourDirections.top)), world.size.div(3).mult(2).floor())
+
+  // world.addAncestor(Ancestor.minimumSelfReproduction(() => AncestorCode.energyCollection(NeighbourDirections.bottom)), world.size.div(5).mult(2).floor())
 }

--- a/src/simulations/modular_life_v2/source.ts
+++ b/src/simulations/modular_life_v2/source.ts
@@ -2,7 +2,7 @@ import p5 from "p5"
 import { Vector } from "../../classes/physics"
 import { defaultCanvasParentId } from "../../react-components/common/default_canvas_parent_id"
 import { Ancestor } from "./ancestor/ancestor"
-import { AncestorCode } from "./ancestor/source_code"
+import { EnergyCollection } from "./ancestor/ancestor_source_code/energy_collection"
 import { constants } from "./constants"
 import { Logger } from "./logger"
 import { P5Drawer } from "./p5_drawer"
@@ -176,9 +176,12 @@ function initializeMaterials(world: World): void {
 }
 
 function initializeAncestors(world: World): void {
-  world.addAncestor(Ancestor.minimumSelfReproduction(() => AncestorCode.energyCollection(NeighbourDirections.bottom)), world.size.div(3).floor())
-  world.addAncestor(Ancestor.minimumSelfReproduction(() => AncestorCode.energyCollection(NeighbourDirections.right)), world.size.div(2).floor())
-  world.addAncestor(Ancestor.minimumSelfReproduction(() => AncestorCode.energyCollection(NeighbourDirections.top)), world.size.div(3).mult(2).floor())
+  world.addAncestor(Ancestor.minimumSelfReproduction(() => (new EnergyCollection(NeighbourDirections.bottom, 1.0))), world.size.div(3).floor())
+  world.addAncestor(Ancestor.minimumSelfReproduction(() => (new EnergyCollection(NeighbourDirections.top, 1.0))), world.size.div(3).floor())
+  world.addAncestor(Ancestor.minimumSelfReproduction(() => (new EnergyCollection(NeighbourDirections.bottom, 0.5))), world.size.div(2).floor())
+  world.addAncestor(Ancestor.minimumSelfReproduction(() => (new EnergyCollection(NeighbourDirections.top, 0.5))), world.size.div(2).floor())
+  world.addAncestor(Ancestor.minimumSelfReproduction(() => (new EnergyCollection(NeighbourDirections.bottom, 0.0))), world.size.div(3).mult(2).floor())
+  world.addAncestor(Ancestor.minimumSelfReproduction(() => (new EnergyCollection(NeighbourDirections.top, 0.0))), world.size.div(3).mult(2).floor())
 
   // world.addAncestor(Ancestor.minimumSelfReproduction(() => AncestorCode.energyCollection(NeighbourDirections.bottom)), world.size.div(5).mult(2).floor())
 }

--- a/src/simulations/modular_life_v2/source.ts
+++ b/src/simulations/modular_life_v2/source.ts
@@ -156,9 +156,11 @@ function initializeEnergySources(world: World): void {
 }
 
 function initializeMaterials(world: World): void {
+  const amount = constants.simulation.substanceAmount
+
   for (let y = 0; y < world.size.y; y += 1) {
     for (let x = 0; x < world.size.x; x += 1) {
-      world.addMaterial("substance", 500, x, y)
+      world.addMaterial("substance", amount, x, y)
     }
   }
 }

--- a/src/simulations/modular_life_v2/system.ts
+++ b/src/simulations/modular_life_v2/system.ts
@@ -1,3 +1,3 @@
 export const System = {
-  version: "2.3.4"
+  version: "2.3.5"
 } as const

--- a/src/simulations/modular_life_v2/system.ts
+++ b/src/simulations/modular_life_v2/system.ts
@@ -1,3 +1,3 @@
 export const System = {
-  version: "2.3.1"
+  version: "2.3.2"
 } as const

--- a/src/simulations/modular_life_v2/system.ts
+++ b/src/simulations/modular_life_v2/system.ts
@@ -1,3 +1,3 @@
 export const System = {
-  version: "2.3.3"
+  version: "2.3.4"
 } as const

--- a/src/simulations/modular_life_v2/system.ts
+++ b/src/simulations/modular_life_v2/system.ts
@@ -1,3 +1,3 @@
 export const System = {
-  version: "2.3.0"
+  version: "2.3.1"
 } as const

--- a/src/simulations/modular_life_v2/system.ts
+++ b/src/simulations/modular_life_v2/system.ts
@@ -1,3 +1,3 @@
 export const System = {
-  version: "2.3.2"
+  version: "2.3.3"
 } as const

--- a/src/simulations/modular_life_v2/system.ts
+++ b/src/simulations/modular_life_v2/system.ts
@@ -1,3 +1,3 @@
 export const System = {
-  version: "2.2.10"
+  version: "2.3.0"
 } as const

--- a/src/simulations/modular_life_v2/world.ts
+++ b/src/simulations/modular_life_v2/world.ts
@@ -1,5 +1,5 @@
 import { guardPositionArgument, Vector } from "../../classes/physics"
-import { Direction, getDirectionVector, NeighbourDirection } from "./physics/direction"
+import { Direction, getDirectionVector, NeighbourDirection, NeighbourDirections } from "./physics/direction"
 import type { ComputerApi } from "./module/api"
 import { Logger } from "./logger"
 import { Terrain, TerrainCell } from "./terrain"
@@ -12,6 +12,7 @@ import type { MaterialAmountMap, MaterialType } from "./physics/material"
 import { AncestorSpec, Spawner } from "./ancestor/spawner"
 import { InternalModuleType } from "./module/module_object/module_object"
 import { Computer } from "./module/module_object/computer"
+import { isHull } from "./module/module_object/hull"
 
 type LifeRequestCache = {
   moveRequest: ComputeRequestMove | null
@@ -210,7 +211,13 @@ export class World {
         },
       },
       environment: {
-        getEnvironmentalHeat(): number {
+        movableDirections(): NeighbourDirection[] {
+          if (isHull(scope)) {
+            return []
+          }
+          return Array.from(Object.values(NeighbourDirections))
+        },
+        getHeat(): number {
           return scope.heat
         },
         getWeight(): number {

--- a/src/simulations/modular_life_v2/world.ts
+++ b/src/simulations/modular_life_v2/world.ts
@@ -62,7 +62,6 @@ export class World {
   public initialize(): void {
     this.terrain.cells.forEach(row => {
       row.forEach(cell => {
-        cell.heat = 1
         cell.scopeUpdate = createScopeUpdate(cell)
       })
     })
@@ -249,10 +248,20 @@ export class World {
         getMoveEnergyConsumption: (): number => {
           return this.engine.calculateMoveEnergyConsumption(life)
         },
+        getRetainEnergyConsumption: (): number => {
+          return this.engine.getRetainEnergyConsumption(life, scope.heat)
+        },
       },
       action: {
         say(message: string): void {
           life.saying = message
+        },
+        retain(energyAmount: number): void {
+          if (energyAmount < life.scopeUpdate.amount.energy) {
+            throw `not enough retain energy ${life.id} (${energyAmount} < ${life.scopeUpdate.amount.energy})`
+          }
+          life.scopeUpdate.amount.energy -= energyAmount
+          life.retainEnergyBank += energyAmount
         },
         move(direction: NeighbourDirection): void {
           if (Object.keys(life.internalModules.mover).length <= 0) {

--- a/src/simulations/modular_life_v2/world.ts
+++ b/src/simulations/modular_life_v2/world.ts
@@ -61,6 +61,7 @@ export class World {
   public initialize(): void {
     this.terrain.cells.forEach(row => {
       row.forEach(cell => {
+        cell.heat = 1
         cell.scopeUpdate = createScopeUpdate(cell)
       })
     })

--- a/src/simulations/modular_life_v2/world.ts
+++ b/src/simulations/modular_life_v2/world.ts
@@ -126,10 +126,10 @@ export class World {
           const destinationCell = this.getTerrainCellAt(destinationPosition)
           destinationCell.scopeUpdate.hullToAdd.add(life)
         })
-
-        this.engine.calculateTerrainCell(cell)
       })
     })
+
+    this.engine.calculateCellEnergyTransfer(this.size, this.terrain.cells)
 
     allScopes.forEach(scope => {
       updateScope(scope, scope.scopeUpdate)

--- a/src/simulations/modular_life_v2/world.ts
+++ b/src/simulations/modular_life_v2/world.ts
@@ -257,8 +257,8 @@ export class World {
           life.saying = message
         },
         retain(energyAmount: number): void {
-          if (energyAmount < life.scopeUpdate.amount.energy) {
-            throw `not enough retain energy ${life.id} (${energyAmount} < ${life.scopeUpdate.amount.energy})`
+          if (energyAmount > life.scopeUpdate.amount.energy) {
+            throw `not enough retain energy (${energyAmount} > ${life.scopeUpdate.amount.energy})`
           }
           life.scopeUpdate.amount.energy -= energyAmount
           life.retainEnergyBank += energyAmount


### PR DESCRIPTION
# 概要
- https://github.com/mitsuyoshi-yamazaki/ALifeLab/issues/163
- 生命同士の相互作用を実装する（物資を介したものでもok
- 物質の独占を禁止する
- assemble APIにHull IDを引数で与えれば複数の子供をつくることや小器官をつくることができる
- 限定的な不老不死：資源を消費することで老化をサスペンドできる
- 最低限物質の増殖などの致命的な問題がないことを目標
  - 細かい整合性は無視する
- Hullはpredefined
  - assembleは内部にHullを持つ場合はその中にモジュールを接続する：なければ自身に接続する
    - つまり入れ子になっている場合は自身の成長はできない
- fuelの合成速度は消費速度を上回らなければならない
  - エネルギー等の取り込み速度も同様
- 物質の使用・排出
  - Factorio方式
    - →将来的に循環系を設計できれば優先順位を決められるようになる
    - internal moduleが必要な物質を一定量ずつ取り込むようにすれば面倒な計算が不要
      - channelは開け閉めと通す物質を制御する
  - 物質の格納上限を厳密に計算するのは難しいので、上限を超えたらダメージが入るなどを検討する
  - ストレージは現tickの容量と格納量から、利用可能量（格納量）と追加可能量（容量の残り）を算出し、tickの間にこのふたつの値を消費して次tickの量を算出する
- 描画
  - 必ずしも情報を全て完全に表示する必要はない
  - 参考：https://twitter.com/datassette/status/1624394179185938432?s=46&t=Topn1EILQh9RC1Vx5ak9SA
- 物質同士の相互作用
  - 物質が多い場所はエネルギーが流れにくいなど、生命現象から物質界へのフィードバック
  - Fuelの実装
- "適温"でない場合に劣化するようにすればどうか
  - つまり温度が低くてもhitsが減る

---

http://localhost:8080/pages/modular_life_v2.html?cell_size=16&world_size=60&frame_skip=1&log_level=debug&heat_damage=0.2&energy_heat_conversion=0.1&substance_amount=12&energy_transfer_resistance=5&energy_production=100
