### PR TITLE
ランダムルール生成法の追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react-dom": "^17.0.1"
   },
   "scripts": {
-    "build": "webpack && python src/html-generator/generate.py && echo '\\007'",
+    "build": "webpack && python3 src/html-generator/generate.py && echo '\\007'",
     "watch": "webpack -w",
     "test": "jest",
     "start": "webpack serve --open --mode development"

--- a/src/simulations/drawer/random_rule_constructor.ts
+++ b/src/simulations/drawer/random_rule_constructor.ts
@@ -1,0 +1,37 @@
+import { random } from "../../classes/utilities"
+import { LSystemCondition } from "./lsystem_rule"
+import { VanillaLSystemRule } from "./vanilla_lsystem_rule"
+
+export const RandomRuleConstructor = {
+  random(): VanillaLSystemRule {
+    const alphabets = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("")
+    const conditions = alphabets.slice(0, random(alphabets.length, 1))
+    const map = new Map<string, LSystemCondition[]>()
+    const maxConditions = 10
+
+    const randomCondition = (): string => {
+      const index = Math.floor(random(conditions.length))
+
+      return conditions[index]
+    }
+
+    conditions.forEach(condition => {
+      const nextConditions: LSystemCondition[] = []
+      for (let i = 0; i < maxConditions; i += 1) {
+        if (random(1) > 0.5) {
+          break
+        }
+        const angle = Math.floor(random(360, 0)) - 180
+        nextConditions.push(angle)
+        nextConditions.push(randomCondition())
+      }
+      if (nextConditions.length === 0) {
+        nextConditions.push(VanillaLSystemRule.endOfBranch)
+      }
+
+      map.set(condition, nextConditions)
+    })
+
+    return new VanillaLSystemRule(map)
+  } 
+}

--- a/src/simulations/drawer/random_rule_constructor.ts
+++ b/src/simulations/drawer/random_rule_constructor.ts
@@ -37,17 +37,66 @@ export const RandomRuleConstructor = {
   },
 
   graph(): VanillaLSystemRule {
-    const conditions = alphabets.slice(0, random(alphabets.length, 1))
+    const allPossibleConditions = [...alphabets]
+    const unusedConditions = new Set(allPossibleConditions)
+
+    const loopConditions = alphabets.slice(0, random(12, 2))
+    loopConditions.forEach(condition => {
+      unusedConditions.delete(condition)
+    })
+
+    const branchConditions: string[] = []
     const map = new Map<string, LSystemCondition[]>()
 
-    conditions.forEach((condition, index) => {
+    const randomCondition = (conditions: string[]): string => {
+      const index = Math.floor(random(conditions.length))
+
+      return conditions[index]
+    }
+
+    loopConditions.forEach((condition, index) => {
       const nextConditions: LSystemCondition[] = []
       const angle = Math.floor(random(360, 0)) - 180
-      nextConditions.push(angle)
 
       nextConditions.push(angle)
-      const destinationCondition = conditions[(index + 1) % conditions.length]
+      const destinationCondition = loopConditions[(index + 1) % loopConditions.length]
       nextConditions.push(destinationCondition)
+
+      for (let i = 0; i < 10; i += 1) {
+        if (random(1) > 0.7) {
+          break
+        }
+        const branchAngle = Math.floor(random(360, 0)) - 180
+        nextConditions.push(branchAngle)
+
+        const branchCondition = randomCondition(allPossibleConditions)
+        if (unusedConditions.has(branchCondition) === true) {
+          unusedConditions.delete(branchCondition)
+          branchConditions.push(branchCondition)
+        }
+        nextConditions.push(branchCondition)
+      }
+
+      map.set(condition, nextConditions)
+    })
+
+    const usedConditions = [
+      ...loopConditions,
+      ...branchConditions,
+    ]
+    branchConditions.forEach(condition => { // 枝分かれ中にのみ登場する条件がない
+      const nextConditions: LSystemCondition[] = []
+      for (let i = 0; i < 10; i += 1) {
+        if (random(1) > 0.5) {
+          break
+        }
+        const angle = Math.floor(random(360, 0)) - 180
+        nextConditions.push(angle)
+        nextConditions.push(randomCondition(usedConditions))
+      }
+      if (nextConditions.length === 0) {
+        nextConditions.push(VanillaLSystemRule.endOfBranch)
+      }
 
       map.set(condition, nextConditions)
     })

--- a/src/simulations/drawer/random_rule_constructor.ts
+++ b/src/simulations/drawer/random_rule_constructor.ts
@@ -2,9 +2,10 @@ import { random } from "../../classes/utilities"
 import { LSystemCondition } from "./lsystem_rule"
 import { VanillaLSystemRule } from "./vanilla_lsystem_rule"
 
+const alphabets = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("")
+
 export const RandomRuleConstructor = {
   random(): VanillaLSystemRule {
-    const alphabets = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("")
     const conditions = alphabets.slice(0, random(alphabets.length, 1))
     const map = new Map<string, LSystemCondition[]>()
     const maxConditions = 10
@@ -32,6 +33,25 @@ export const RandomRuleConstructor = {
       map.set(condition, nextConditions)
     })
 
+    return new VanillaLSystemRule(map)  // TODO: 死枝の除外等もこの処理の中に移す
+  },
+
+  graph(): VanillaLSystemRule {
+    const conditions = alphabets.slice(0, random(alphabets.length, 1))
+    const map = new Map<string, LSystemCondition[]>()
+
+    conditions.forEach((condition, index) => {
+      const nextConditions: LSystemCondition[] = []
+      const angle = Math.floor(random(360, 0)) - 180
+      nextConditions.push(angle)
+
+      nextConditions.push(angle)
+      const destinationCondition = conditions[(index + 1) % conditions.length]
+      nextConditions.push(destinationCondition)
+
+      map.set(condition, nextConditions)
+    })
+
     return new VanillaLSystemRule(map)
-  } 
+  },
 }

--- a/src/simulations/drawer/source.ts
+++ b/src/simulations/drawer/source.ts
@@ -101,7 +101,6 @@ function createModel(ruleString?: string): Model {
       const tries = 20
       for (let j = 0; j < tries; j += 1) {
         const rule = VanillaLSystemRule.trimUnreachableConditions(RandomRuleConstructor.graph(), initialCondition)
-        console.log("graph")
         if (rule.isCirculated(initialCondition)) {
           rules.push(rule)
           break

--- a/src/simulations/drawer/source.ts
+++ b/src/simulations/drawer/source.ts
@@ -100,7 +100,8 @@ function createModel(ruleString?: string): Model {
     for (let i = 0; i < constants.simulation.numberOfSeeds; i += 1) {
       const tries = 20
       for (let j = 0; j < tries; j += 1) {
-        const rule = VanillaLSystemRule.trimUnreachableConditions(RandomRuleConstructor.random(), initialCondition)
+        const rule = VanillaLSystemRule.trimUnreachableConditions(RandomRuleConstructor.graph(), initialCondition)
+        console.log("graph")
         if (rule.isCirculated(initialCondition)) {
           rules.push(rule)
           break
@@ -108,6 +109,7 @@ function createModel(ruleString?: string): Model {
       }
     }
     if (rules.length === 0) {
+      console.log("random rule generation failed.. drawing predefined patterns")
       rules.push(new VanillaLSystemRule(randomExampleRule()))
     }
   }

--- a/src/simulations/drawer/source.ts
+++ b/src/simulations/drawer/source.ts
@@ -8,6 +8,7 @@ import { VanillaLSystemRule } from "./vanilla_lsystem_rule"
 import { exampleRules } from "./rule_examples"
 import { Downloader } from "./downloader"
 import { TransitionColoredModel } from "./transition_colored_model"
+import { RandomRuleConstructor } from "./random_rule_constructor"
 
 let t = 0
 const canvasId = "canvas"
@@ -99,7 +100,7 @@ function createModel(ruleString?: string): Model {
     for (let i = 0; i < constants.simulation.numberOfSeeds; i += 1) {
       const tries = 20
       for (let j = 0; j < tries; j += 1) {
-        const rule = VanillaLSystemRule.trimUnreachableConditions(VanillaLSystemRule.random(), initialCondition)
+        const rule = VanillaLSystemRule.trimUnreachableConditions(RandomRuleConstructor.random(), initialCondition)
         if (rule.isCirculated(initialCondition)) {
           rules.push(rule)
           break

--- a/src/simulations/drawer/vanilla_lsystem_rule.ts
+++ b/src/simulations/drawer/vanilla_lsystem_rule.ts
@@ -1,4 +1,3 @@
-import { random } from "../../classes/utilities"
 import { Color } from "../../classes/color"
 import { LSystemRule, LSystemCondition, LSystemCoordinate } from "./lsystem_rule"
 
@@ -50,7 +49,8 @@ export class VanillaLSystemRule implements LSystemRule {
     return this._encoded
   }
 
-  private static endOfBranch = "."
+  public static endOfBranch = "."
+  
   private _encoded: string
   private _map: Map<string, LSystemCondition[]>
 
@@ -74,38 +74,6 @@ export class VanillaLSystemRule implements LSystemRule {
       this._map = first
     }
     this.transition = this.calculateTransition()
-  }
-
-  public static random(): VanillaLSystemRule { // FixMe: 適当に書いたので探索範囲が偏っているはず
-    const alphabets = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("")
-    const conditions = alphabets.slice(0, random(alphabets.length, 1))
-    const map = new Map<string, LSystemCondition[]>()
-    const maxConditions = 10
-
-    const randomCondition = (): string => {
-      const index = Math.floor(random(conditions.length))
-
-      return conditions[index]
-    }
-
-    conditions.forEach(condition => {
-      const nextConditions: LSystemCondition[] = []
-      for (let i = 0; i < maxConditions; i += 1) {
-        if (random(1) > 0.5) {
-          break
-        }
-        const angle = Math.floor(random(360, 0)) - 180
-        nextConditions.push(angle)
-        nextConditions.push(randomCondition())
-      }
-      if (nextConditions.length === 0) {
-        nextConditions.push(VanillaLSystemRule.endOfBranch)
-      }
-
-      map.set(condition, nextConditions)
-    })
-
-    return new VanillaLSystemRule(map)
   }
 
   public static encode(map: Map<string, LSystemCondition[]>): string {

--- a/src/simulations/drawer_mortal/source.ts
+++ b/src/simulations/drawer_mortal/source.ts
@@ -8,6 +8,7 @@ import { VanillaLSystemRule } from "../drawer/vanilla_lsystem_rule"
 import { Downloader } from "../drawer/downloader"
 import { exampleRules } from "./rule_examples"
 import { MortalModel } from "./mortal_model"
+import { RandomRuleConstructor } from "../drawer/random_rule_constructor"
 
 let t = 0
 const canvasId = "canvas"
@@ -85,7 +86,7 @@ function createModel(ruleStrings: string[]): Model {
     for (let i = 0; i < constants.simulation.numberOfSeeds; i += 1) {
       const tries = 20
       for (let j = 0; j < tries; j += 1) {
-        const rule = VanillaLSystemRule.trimUnreachableConditions(VanillaLSystemRule.random(), initialCondition)
+        const rule = VanillaLSystemRule.trimUnreachableConditions(RandomRuleConstructor.random(), initialCondition)
         if (rule.isCirculated(initialCondition)) {
           rules.push(rule)
           break


### PR DESCRIPTION
- より複雑な構造を生成する

# ランダムルール生成法
## グラフ
- ルールの構造は循環するコアループとそこからの枝分かれに分割できる
- それぞれ生成する
- コアループのパラメータは状態数のみ
- コアループの各状態は任意の状態遷移と置換可能

---

# 採集：
- ピックアップしたパターンのいい感じの要素/構造を司るパラメータを抜き出す
  - 要素：あるノードから始まり収束するパターン
  - 構造：あるノードから始まりループするパターン